### PR TITLE
Delete DB - uninstall hook

### DIFF
--- a/woosms-sms-module-for-woocommerce.php
+++ b/woosms-sms-module-for-woocommerce.php
@@ -53,6 +53,11 @@ if (is_plugin_active('woocommerce/woocommerce.php')) {
 		]);
 	}
 
+	function BulkGateUninstallPlugin()
+	{
+		Factory::get()->getByClass(Settings::class)->uninstall();
+	}
+
 
 	/**
 	 * Init BulkGate DI container
@@ -85,7 +90,7 @@ if (is_plugin_active('woocommerce/woocommerce.php')) {
 	/**
 	 * Register uninstall scripts
 	 */
-	register_deactivation_hook(__FILE__, fn () => Factory::get()->getByClass(Settings::class)->uninstall());
+	register_uninstall_hook(__FILE__, 'BulkGateUninstallPlugin');
 
 } else {
 


### PR DESCRIPTION
Aktualne se modul nechova tak, jak by mel podle dokumentace viz. https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/.
Zde je tabulka porovnani mezi deaktivaci a odinstalaci: https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/

Podle dokumentace se doporucuje mazat tabulky pouze pri odinstalaci. 

Muzeme se bavit treba o tom, jestli pri aktivaci/deaktivaci treba pouze nenastavovat nektere hodnoty v databazi (synchronization), abychom treba vynutili synchronizaci...